### PR TITLE
Hardcode the toolname (ksonnet)

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -10,9 +10,7 @@ set \
 : ${ASDF_INSTALL_VERSION?}
 : ${ASDF_INSTALL_PATH?}
 
-# detect the tool name
-readonly __dirname="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly toolname="$(basename "$(dirname "${__dirname}")")"
+readonly toolname="ksonnet"
 
 # make a temporary download directory with a cleanup hook
 readonly TMP_DOWNLOAD_DIR="$(mktemp -d -t "asdf_${toolname}_XXXXXX")"

--- a/bin/list-all
+++ b/bin/list-all
@@ -5,9 +5,7 @@ set \
   -o pipefail \
   -o errexit
 
-# detect the tool name
-readonly __dirname="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly toolname="$(basename "$(dirname "${__dirname}")")"
+readonly toolname="ksonnet"
 
 readonly SEMVER_REGEX='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?'
 


### PR DESCRIPTION
This fixes #1.

Not sure if this is the best way of going about it, but it allowed me to
install 0.8.0.